### PR TITLE
Fix timezone for Eventbrite events.

### DIFF
--- a/constructor/app.js
+++ b/constructor/app.js
@@ -219,8 +219,8 @@ function fetchICSFromEventBrite(cb) {
                     var ev = ics.addComponent('VEVENT');
                     ev.setSummary(ebev.name.text);
                     var start = new Date(), end = new Date();
-                    start.setTime(Date.parse(ebev.start.local));
-                    end.setTime(Date.parse(ebev.end.local));
+                    start.setTime(Date.parse(ebev.start.utc));
+                    end.setTime(Date.parse(ebev.end.utc));
                     ev.setDate(start, end);
                     if(ebev.venue) {
                         var ven = ebev.venue.name;


### PR DESCRIPTION
At present, Eventbrite events show up in the calendar as starting and ending one hour late, because of BST getting applied twice.