### PR TITLE
Tags and dry run

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ calendar
 ========
 
 A comprehensive calendar of [Birmingham tech events](http://calendar.birmingham.io)
+
+To get your event in this calendar, the easiest way is to put it in the Technology category or Technology topic on Meetup, and make it be in Birmingham.

--- a/constructor/README.md
+++ b/constructor/README.md
@@ -1,1 +1,8 @@
 Static site generator and calendar generator for calendar of [Birmingham tech events](http://calendar.birmingham.io)
+
+Execute as `node app.js` to fetch the calendar items from all the sources and update the Google calendar.
+Execute as `node createWebsite.js` to create the calendar.Birmingham.IO static website from the calendar.
+
+Execute as `node app.js --dryrun` to fetch all the calendar items from sources and print them out, but _not_ update the Google calendar. 
+
+`node app.js --help` will show other command options to turn on logging at various levels.


### PR DESCRIPTION
Add the `--dryrun` parameter to allow running the script without actually updating the calendar.

Add a second Meetup search, to search by tag as well as category, so we not only search for meetups in the Technology category (34) but also in various technology-related topics.